### PR TITLE
Comparison Macros

### DIFF
--- a/sdmap/src/sdmap.ext.Dapper/sdmap.ext.Dapper.csproj
+++ b/sdmap/src/sdmap.ext.Dapper/sdmap.ext.Dapper.csproj
@@ -13,13 +13,13 @@ https://github.com/sdcb/sdmap/blob/master/ReleaseNotes.md</PackageReleaseNotes>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>0.16.4</Version>
+    <Version>0.16.5</Version>
     <Description>Dapper extensions for sdmap.</Description>
     <PackageProjectUrl>https://github.com/sdcb/sdmap</PackageProjectUrl>
     <Authors>sdcb</Authors>
     <Copyright>MIT</Copyright>
-    <AssemblyVersion>0.16.4</AssemblyVersion>
-    <FileVersion>0.16.4</FileVersion>
+    <AssemblyVersion>0.16.5</AssemblyVersion>
+    <FileVersion>0.16.5</FileVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/sdmap/src/sdmap.ext.Dapper/sdmap.ext.Dapper.csproj
+++ b/sdmap/src/sdmap.ext.Dapper/sdmap.ext.Dapper.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>sdmap.ext.Dapper</AssemblyName>
     <PackageId>sdmap.ext.Dapper</PackageId>
     <PackageTags>dynamic sql;sdmap;dapper</PackageTags>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageReleaseNotes>For more information, please view:
 https://github.com/sdcb/sdmap/blob/master/ReleaseNotes.md</PackageReleaseNotes>
     <PackageLicenseUrl></PackageLicenseUrl>

--- a/sdmap/src/sdmap.ext/sdmap.ext.csproj
+++ b/sdmap/src/sdmap.ext/sdmap.ext.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>sdmap.ext</AssemblyName>
     <PackageId>sdmap.ext</PackageId>
     <PackageTags>dynamic sql;sdmap</PackageTags>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageReleaseNotes>For more information, please view:
 https://github.com/sdcb/sdmap/blob/master/ReleaseNotes.md</PackageReleaseNotes>
     <PackageLicenseUrl></PackageLicenseUrl>

--- a/sdmap/src/sdmap.ext/sdmap.ext.csproj
+++ b/sdmap/src/sdmap.ext/sdmap.ext.csproj
@@ -13,13 +13,13 @@ https://github.com/sdcb/sdmap/blob/master/ReleaseNotes.md</PackageReleaseNotes>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>0.16.4</Version>
+    <Version>0.16.5</Version>
     <Description>Useful extensions for sdmap/Dapper.</Description>
     <PackageProjectUrl>https://github.com/sdcb/sdmap</PackageProjectUrl>
     <Authors>sdcb</Authors>
     <Copyright>MIT</Copyright>
-    <AssemblyVersion>0.16.4</AssemblyVersion>
-    <FileVersion>0.16.4</FileVersion>
+    <AssemblyVersion>0.16.5</AssemblyVersion>
+    <FileVersion>0.16.5</FileVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/sdmap/src/sdmap/Macros/Implements/RuntimeMacros.cs
+++ b/sdmap/src/sdmap/Macros/Implements/RuntimeMacros.cs
@@ -204,7 +204,7 @@ namespace sdmap.Macros.Implements
         }
 
         [Macro("isLessThan")]
-        [MacroArguments(SdmapTypes.Syntax, SdmapTypes.Number, SdmapTypes.StringOrSql)]
+        [MacroArguments(SdmapTypes.Syntax, SdmapTypes.Any, SdmapTypes.StringOrSql)]
         public static Result<string> IsLessThan(OneCallContext context,
             string ns, object self, object[] arguments)
         {
@@ -224,7 +224,7 @@ namespace sdmap.Macros.Implements
         }
 
         [Macro("isGreaterThan")]
-        [MacroArguments(SdmapTypes.Syntax, SdmapTypes.Number, SdmapTypes.StringOrSql)]
+        [MacroArguments(SdmapTypes.Syntax, SdmapTypes.Any, SdmapTypes.StringOrSql)]
         public static Result<string> IsGreaterThan(OneCallContext context,
             string ns, object self, object[] arguments)
         {
@@ -244,7 +244,7 @@ namespace sdmap.Macros.Implements
         }
 
         [Macro("isLessEqual")]
-        [MacroArguments(SdmapTypes.Syntax, SdmapTypes.Number, SdmapTypes.StringOrSql)]
+        [MacroArguments(SdmapTypes.Syntax, SdmapTypes.Any, SdmapTypes.StringOrSql)]
         public static Result<string> IsLessEqual(OneCallContext context,
             string ns, object self, object[] arguments)
         {
@@ -264,7 +264,7 @@ namespace sdmap.Macros.Implements
         }
 
         [Macro("isGreaterEqual")]
-        [MacroArguments(SdmapTypes.Syntax, SdmapTypes.Number, SdmapTypes.StringOrSql)]
+        [MacroArguments(SdmapTypes.Syntax, SdmapTypes.Any, SdmapTypes.StringOrSql)]
         public static Result<string> IsGreaterEqual(OneCallContext context,
             string ns, object self, object[] arguments)
         {

--- a/sdmap/src/sdmap/Macros/Implements/RuntimeMacros.cs
+++ b/sdmap/src/sdmap/Macros/Implements/RuntimeMacros.cs
@@ -178,7 +178,7 @@ namespace sdmap.Macros.Implements
             string syntax = (string)arguments[0];
             var val = GetPropValue(self, syntax);
             var compare = arguments[1];
-            if (IsEqual(val, compare))
+            if (ValueComparer.IsEqual(val, compare))
                 return MacroUtil.EvalToString(arguments[2], context, self);
             
             return Empty;
@@ -197,7 +197,7 @@ namespace sdmap.Macros.Implements
             string syntax = (string)arguments[0];
             var val = GetPropValue(self, syntax);
             var compare = arguments[1];
-            if (!IsEqual(val, compare))
+            if (!ValueComparer.IsEqual(val, compare))
                 return MacroUtil.EvalToString(arguments[2], context, self);
 
             return Empty;
@@ -475,40 +475,6 @@ namespace sdmap.Macros.Implements
                 return props.Aggregate(self, (s, p) =>
                     s?.GetType().GetTypeInfo().GetProperty(p)?.GetValue(s));
             }
-        }
-
-        public static bool IsEqual(object v1, object v2)
-        {
-            if (v1 is string str)
-                return str.Equals((string)v2);
-
-            if (v1 is bool b)
-                return b.Equals((bool)v2);
-
-            if (v1 is int integer)
-                return integer.Equals(Convert.ToInt32(v2));
-
-            if (v1 is long longValue)
-                return longValue.Equals(Convert.ToInt64(v2));
-
-            if (v1 is double db)
-                return db.Equals(Convert.ToDouble(v2));
-
-            if (v1 is decimal dm)
-                return dm.Equals(Convert.ToDecimal(v2));
-
-            if (v1 is DateTime date)
-                return date.Equals((DateTime)v2);
-
-            if (v1 is Enum @enum)
-            {
-                if (v2 is string v2s)
-                    return @enum.ToString() == v2s;
-                if (v2 is double v2d)
-                    return Convert.ToInt64(@enum) == v2d;
-            }
-
-            return v1 == v2;
         }
 
         public static bool IsEmpty(object v)

--- a/sdmap/src/sdmap/Macros/Implements/RuntimeMacros.cs
+++ b/sdmap/src/sdmap/Macros/Implements/RuntimeMacros.cs
@@ -178,7 +178,7 @@ namespace sdmap.Macros.Implements
             string syntax = (string)arguments[0];
             var val = GetPropValue(self, syntax);
             var compare = arguments[1];
-            if (ValueComparer.IsEqual(val, compare))
+            if (ValueComparer.Compare(val, compare) is ComparisonResult.AreEqual)
                 return MacroUtil.EvalToString(arguments[2], context, self);
             
             return Empty;
@@ -197,7 +197,7 @@ namespace sdmap.Macros.Implements
             string syntax = (string)arguments[0];
             var val = GetPropValue(self, syntax);
             var compare = arguments[1];
-            if (!ValueComparer.IsEqual(val, compare))
+            if (ValueComparer.Compare(val, compare) is not ComparisonResult.AreEqual)
                 return MacroUtil.EvalToString(arguments[2], context, self);
 
             return Empty;

--- a/sdmap/src/sdmap/Macros/Implements/RuntimeMacros.cs
+++ b/sdmap/src/sdmap/Macros/Implements/RuntimeMacros.cs
@@ -214,9 +214,10 @@ namespace sdmap.Macros.Implements
             if (prop == null) return RequirePropNotNull(arguments[0]);
 
             string syntax = (string)arguments[0];
-            var val = GetPropValue(self, syntax);
-            var compare = Convert.ToDouble(arguments[1]);
-            if (Convert.ToDouble(val) < compare)
+            var left = GetPropValue(self, syntax);
+            var right = arguments[1];
+
+            if (ValueComparer.Compare(left, right) is ComparisonResult.LeftIsLess)
                 return MacroUtil.EvalToString(arguments[2], context, self);
 
             return Empty;
@@ -233,9 +234,10 @@ namespace sdmap.Macros.Implements
             if (prop == null) return RequirePropNotNull(arguments[0]);
 
             string syntax = (string)arguments[0];
-            var val = GetPropValue(self, syntax);
-            var compare = Convert.ToDouble(arguments[1]);
-            if (Convert.ToDouble(val) > compare)
+            var left = GetPropValue(self, syntax);
+            var right = arguments[1];
+
+            if (ValueComparer.Compare(left, right) is ComparisonResult.LeftIsGreater)
                 return MacroUtil.EvalToString(arguments[2], context, self);
 
             return Empty;
@@ -252,9 +254,10 @@ namespace sdmap.Macros.Implements
             if (prop == null) return RequirePropNotNull(arguments[0]);
 
             string syntax = (string)arguments[0];
-            var val = GetPropValue(self, syntax);
-            var compare = Convert.ToDouble(arguments[1]);
-            if (Convert.ToDouble(val) <= compare)
+            var left = GetPropValue(self, syntax);
+            var right = arguments[1];
+
+            if (ValueComparer.Compare(left, right) is ComparisonResult.LeftIsLess or ComparisonResult.AreEqual)
                 return MacroUtil.EvalToString(arguments[2], context, self);
 
             return Empty;
@@ -271,9 +274,10 @@ namespace sdmap.Macros.Implements
             if (prop == null) return RequirePropNotNull(arguments[0]);
 
             string syntax = (string)arguments[0];
-            var val = GetPropValue(self, syntax);
-            var compare = Convert.ToDouble(arguments[1]);
-            if (Convert.ToDouble(val) >= compare)
+            var left = GetPropValue(self, syntax);
+            var right = arguments[1];
+
+            if (ValueComparer.Compare(left, right) is ComparisonResult.LeftIsGreater or ComparisonResult.AreEqual)
                 return MacroUtil.EvalToString(arguments[2], context, self);
 
             return Empty;

--- a/sdmap/src/sdmap/Macros/Implements/ValueComparer.cs
+++ b/sdmap/src/sdmap/Macros/Implements/ValueComparer.cs
@@ -5,13 +5,12 @@ using System.Reflection;
 
 namespace sdmap.Macros.Implements;
 
-[Flags]
 public enum ComparisonResult : byte
 {
-    Incomparable  = 1,
-    AreEqual      = 2,
-    LeftIsGreater = 4,
-    LeftIsLess    = 8
+    Incomparable = 1,
+    AreEqual,
+    LeftIsGreater,
+    LeftIsLess
 }
 
 internal static class ValueComparer

--- a/sdmap/src/sdmap/Macros/Implements/ValueComparer.cs
+++ b/sdmap/src/sdmap/Macros/Implements/ValueComparer.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace sdmap.Macros.Implements;
+
+internal class ValueComparer : IComparer<object>
+{
+    private ValueComparer()
+    {
+    }
+    
+    public static IComparer<object> Instance { get; } = new ValueComparer();
+
+    public int Compare(object x, object y)
+    {
+        throw new NotImplementedException();
+    }
+    
+    public static bool IsEqual(object v1, object v2)
+        => v1 switch
+        {
+            null                     => v2 is null,
+            not null when v2 is null => false,
+
+            byte    byteValue    => byteValue.Equals(Convert.ToByte(v2)),
+            sbyte   sByteValue   => sByteValue.Equals(Convert.ToSByte(v2)),
+            short   shortValue   => shortValue.Equals(Convert.ToInt16(v2)),
+            ushort  ushortValue  => ushortValue.Equals(Convert.ToUInt16(v2)),
+
+            int     intValue     => intValue.Equals(Convert.ToInt32(v2)),
+            uint    uIntValue    => uIntValue.Equals(Convert.ToUInt32(v2)),
+            long    longValue    => longValue.Equals(Convert.ToInt64(v2)),
+            ulong   uLongValue   => uLongValue.Equals(Convert.ToUInt64(v2)),
+
+            float   floatValue   => floatValue.Equals(Convert.ToSingle(v2)),
+            double  doubleValue  => doubleValue.Equals(Convert.ToDouble(v2)),
+            decimal decimalValue => decimalValue.Equals(Convert.ToDecimal(v2)),
+
+            Enum enumValue
+                => v2 is Enum other
+                    ? enumValue.Equals(other)
+                    : EnumParser.TryParse(enumValue.GetType(), v2.ToString(), out var parsed)
+                      && enumValue.Equals(parsed),
+
+            Guid guid
+                => v2 is Guid other
+                    ? guid.Equals(other)
+                    : Guid.TryParse(v2.ToString(), out var parsed) && guid.Equals(parsed),
+
+            TimeSpan timeSpan
+                => v2 is TimeSpan other
+                    ? timeSpan.Equals(other)
+                    : TimeSpan.TryParse(v2.ToString(), out var parsed) && timeSpan.Equals(parsed),
+
+            DateTime dateTime
+                => v2 is DateTime other
+                    ? dateTime.Equals(other)
+                    : DateTime.TryParse(v2.ToString(), out var parsed) && dateTime.Equals(parsed),
+
+            DateTimeOffset dateTimeOffset
+                => v2 is DateTimeOffset other
+                    ? dateTimeOffset.Equals(other)
+                    : DateTimeOffset.TryParse(v2.ToString(), out var parsed) && dateTimeOffset.Equals(parsed),
+
+            _ => v1.Equals(v2)
+        };
+
+    private static class EnumParser
+    {
+        private static readonly MethodInfo TryParseMethod
+            = typeof(Enum)
+                .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Single(method =>
+                    method.Name == nameof(Enum.TryParse)
+                    && method.IsGenericMethodDefinition
+                    && method.ReturnType == typeof(bool)
+                    && method.GetParameters().Length == 3
+                    && method.GetParameters().First().ParameterType == typeof(string)
+                );
+
+        public static bool TryParse(Type enumType, string value, out object parsed)
+        {
+            var parameters = new object[] { value, true, null };
+
+            var result = TryParseMethod
+                .MakeGenericMethod(enumType)
+                .Invoke(obj: null, parameters);
+
+            parsed = parameters[2];
+            return (bool)result;
+        }
+    }
+}

--- a/sdmap/src/sdmap/sdmap.csproj
+++ b/sdmap/src/sdmap/sdmap.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>sdmap</AssemblyName>
     <PackageId>sdmap</PackageId>
     <PackageTags>dynamic sql;ibatis</PackageTags>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageReleaseNotes>https://github.com/sdcb/sdmap/blob/master/ReleaseNotes.md</PackageReleaseNotes>
     <PackageLicenseUrl></PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>

--- a/sdmap/src/sdmap/sdmap.csproj
+++ b/sdmap/src/sdmap/sdmap.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Description>A template engine for writing dynamic sql.</Description>
     <TargetFrameworks>net6;netstandard20</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <AssemblyName>sdmap</AssemblyName>
     <PackageId>sdmap</PackageId>
     <PackageTags>dynamic sql;ibatis</PackageTags>

--- a/sdmap/src/sdmap/sdmap.csproj
+++ b/sdmap/src/sdmap/sdmap.csproj
@@ -14,9 +14,9 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>0.16.4</Version>
-    <AssemblyVersion>0.16.4</AssemblyVersion>
-    <FileVersion>0.16.4</FileVersion>
+    <Version>0.16.5</Version>
+    <AssemblyVersion>0.16.5</AssemblyVersion>
+    <FileVersion>0.16.5</FileVersion>
     <Authors>sdcb</Authors>
     <Copyright>MIT</Copyright>
     <PackageProjectUrl>https://github.com/sdcb/sdmap</PackageProjectUrl>

--- a/sdmap/test/sdmap.test/ValueComparerTests.cs
+++ b/sdmap/test/sdmap.test/ValueComparerTests.cs
@@ -5,89 +5,96 @@ using Xunit;
 
 namespace sdmap.test;
 
+using static ComparisonResult;
+
 public class ValueComparerTests
 {
     [Theory]
-    [MemberData(nameof(IsEqual_Cases_Number))]
-    [MemberData(nameof(IsEqual_Cases_Enum))]
-    [MemberData(nameof(IsEqual_Cases_Guid))]
-    [MemberData(nameof(IsEqual_Cases_Timespan))]
-    [MemberData(nameof(IsEqual_Cases_DateTime))]
-    public void IsEqual(object left, object right, bool areEqual)
+    [MemberData(nameof(Compare_Cases_Number))]
+    [MemberData(nameof(Compare_Cases_Enum))]
+    [MemberData(nameof(Compare_Cases_Guid))]
+    [MemberData(nameof(Compare_Cases_Timespan))]
+    [MemberData(nameof(Compare_Cases_DateTime))]
+    public void Compare(object left, object right, ComparisonResult expected)
     {
-        var actual = ValueComparer.IsEqual(left, right);
-        Assert.Equal(areEqual, actual);
+        var actual = ValueComparer.Compare(left, right);
+        Assert.Equal(expected, actual);
     }
 
-    public static IEnumerable<object[]> IsEqual_Cases_Number()
+    public static IEnumerable<object[]> Compare_Cases_Number()
     {
-        yield return new object[] { 0, 0, true };
-        yield return new object[] { 0, 0L, true };
-        yield return new object[] { (short) 1, 1L, true };
-        yield return new object[] { (byte) 1, (ulong) 1, true };
+        yield return new object[] { 0, 0, AreEqual };
+        yield return new object[] { 0, 0L, AreEqual };
+        yield return new object[] { (short) 1, 1L, AreEqual };
+        yield return new object[] { (byte) 1, (ulong) 1, AreEqual };
 
-        yield return new object[] { 1D, 1F, true };
-        yield return new object[] { 1M, 1M, true };
-        yield return new object[] { 1M, 1D, true };
-        yield return new object[] { 1M, 0D, false };
+        yield return new object[] { 1D, 1F, AreEqual };
+        yield return new object[] { 1M, 1M, AreEqual };
+        yield return new object[] { 1M, 1D, AreEqual };
+        yield return new object[] { 1M, 0D, LeftIsGreater };
 
-        yield return new object[] { 1M, "1", true };
+        yield return new object[] { 1M, "1", AreEqual };
     }
 
-    public static IEnumerable<object[]> IsEqual_Cases_Enum()
+    public static IEnumerable<object[]> Compare_Cases_Enum()
     {
-        yield return new object[] { FirstEnum.One, FirstEnum.One, true };
-        yield return new object[] { FirstEnum.One, FirstEnum.Two, false };
-        yield return new object[] { FirstEnum.One, SecondEnum.One, false };
-        yield return new object[] { FirstEnum.One, SecondEnum.Two, false };
+        yield return new object[] { FirstEnum.One, FirstEnum.One, AreEqual };
+        yield return new object[] { FirstEnum.One, FirstEnum.Two, LeftIsLess };
+        yield return new object[] { FirstEnum.One, SecondEnum.One, Incomparable };
+        yield return new object[] { FirstEnum.One, SecondEnum.Two, Incomparable };
 
-        yield return new object[] { FirstEnum.One, 1, true };
-        yield return new object[] { FirstEnum.One, "1", true };
-        yield return new object[] { FirstEnum.One, "One", true };
-        yield return new object[] { FirstEnum.One, 1.0M, false };
+        yield return new object[] { FirstEnum.One, 1, AreEqual };
+        yield return new object[] { FirstEnum.One, "1", AreEqual };
+        yield return new object[] { FirstEnum.One, "One", AreEqual };
+        yield return new object[] { FirstEnum.One, 1.0M, Incomparable };
     }
 
-    public static IEnumerable<object[]> IsEqual_Cases_Guid()
+    public static IEnumerable<object[]> Compare_Cases_Guid()
     {
         yield return new object[]
         {
             new Guid("01d1692d-2221-47cd-892b-4a6552c6a9cc"),
             new Guid("01d1692d-2221-47cd-892b-4a6552c6a9cc"),
-            true
+            AreEqual
         };
 
         yield return new object[]
         {
             new Guid("01d1692d-2221-47cd-892b-4a6552c6a9cc"),
             "01d1692d-2221-47cd-892b-4a6552c6a9cc",
-            true
+            AreEqual
         };
 
-        yield return new object[] { Guid.NewGuid(), Guid.NewGuid(), false };
+        yield return new object[]
+        {
+            new Guid("00000000-0000-0000-0000-000000000000"),
+            new Guid("11111111-0000-0000-0000-000000000000"),
+            LeftIsLess
+        };
 
         yield return new object[]
         {
             new Guid("01d1692d-2221-47cd-892b-4a6552c6a9cc"),
             DateTime.Now,
-            false
+            Incomparable
         };
     }
     
-    public static IEnumerable<object[]> IsEqual_Cases_Timespan()
+    public static IEnumerable<object[]> Compare_Cases_Timespan()
     {
-        yield return new object[] { TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), true };
-        yield return new object[] { TimeSpan.FromSeconds(1), "00:00:01", true };
-        yield return new object[] { TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(0), false };
-        yield return new object[] { TimeSpan.FromSeconds(1), "10", false };
-        yield return new object[] { TimeSpan.FromSeconds(1), DateTime.Now, false };
+        yield return new object[] { TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), AreEqual };
+        yield return new object[] { TimeSpan.FromSeconds(1), "00:00:01", AreEqual };
+        yield return new object[] { TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(0), LeftIsGreater };
+        yield return new object[] { TimeSpan.FromSeconds(1), "ten seconds", Incomparable };
+        yield return new object[] { TimeSpan.FromSeconds(1), DateTime.Now, Incomparable };
     }
 
-    public static IEnumerable<object[]> IsEqual_Cases_DateTime()
+    public static IEnumerable<object[]> Compare_Cases_DateTime()
     {
-        yield return new object[] { new DateTime(2023, 01, 01), new DateTime(2023, 01, 01), true };
-        yield return new object[] { new DateTime(2023, 01, 01), new DateTime(1900, 01, 01), false };
-        yield return new object[] { new DateTime(2023, 01, 01), "2023-01-01", true };
-        yield return new object[] { DateTime.Now, TimeSpan.FromSeconds(0), false };
+        yield return new object[] { new DateTime(2023, 01, 01), new DateTime(2023, 01, 01), AreEqual };
+        yield return new object[] { new DateTime(2023, 01, 01), new DateTime(1900, 01, 01), LeftIsGreater };
+        yield return new object[] { new DateTime(2023, 01, 01), "2023-01-01", AreEqual };
+        yield return new object[] { DateTime.Now, "today", Incomparable };
     }
 
     private enum FirstEnum { One = 1, Two = 2 }

--- a/sdmap/test/sdmap.test/ValueComparerTests.cs
+++ b/sdmap/test/sdmap.test/ValueComparerTests.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using sdmap.Macros.Implements;
+using Xunit;
+
+namespace sdmap.test;
+
+public class ValueComparerTests
+{
+    [Theory]
+    [MemberData(nameof(IsEqual_Cases_Number))]
+    [MemberData(nameof(IsEqual_Cases_Enum))]
+    [MemberData(nameof(IsEqual_Cases_Guid))]
+    [MemberData(nameof(IsEqual_Cases_Timespan))]
+    [MemberData(nameof(IsEqual_Cases_DateTime))]
+    public void IsEqual(object left, object right, bool areEqual)
+    {
+        var actual = ValueComparer.IsEqual(left, right);
+        Assert.Equal(areEqual, actual);
+    }
+
+    public static IEnumerable<object[]> IsEqual_Cases_Number()
+    {
+        yield return new object[] { 0, 0, true };
+        yield return new object[] { 0, 0L, true };
+        yield return new object[] { (short) 1, 1L, true };
+        yield return new object[] { (byte) 1, (ulong) 1, true };
+
+        yield return new object[] { 1D, 1F, true };
+        yield return new object[] { 1M, 1M, true };
+        yield return new object[] { 1M, 1D, true };
+        yield return new object[] { 1M, 0D, false };
+
+        yield return new object[] { 1M, "1", true };
+    }
+
+    public static IEnumerable<object[]> IsEqual_Cases_Enum()
+    {
+        yield return new object[] { FirstEnum.One, FirstEnum.One, true };
+        yield return new object[] { FirstEnum.One, FirstEnum.Two, false };
+        yield return new object[] { FirstEnum.One, SecondEnum.One, false };
+        yield return new object[] { FirstEnum.One, SecondEnum.Two, false };
+
+        yield return new object[] { FirstEnum.One, 1, true };
+        yield return new object[] { FirstEnum.One, "1", true };
+        yield return new object[] { FirstEnum.One, "One", true };
+        yield return new object[] { FirstEnum.One, 1.0M, false };
+    }
+
+    public static IEnumerable<object[]> IsEqual_Cases_Guid()
+    {
+        yield return new object[]
+        {
+            new Guid("01d1692d-2221-47cd-892b-4a6552c6a9cc"),
+            new Guid("01d1692d-2221-47cd-892b-4a6552c6a9cc"),
+            true
+        };
+
+        yield return new object[]
+        {
+            new Guid("01d1692d-2221-47cd-892b-4a6552c6a9cc"),
+            "01d1692d-2221-47cd-892b-4a6552c6a9cc",
+            true
+        };
+
+        yield return new object[] { Guid.NewGuid(), Guid.NewGuid(), false };
+
+        yield return new object[]
+        {
+            new Guid("01d1692d-2221-47cd-892b-4a6552c6a9cc"),
+            DateTime.Now,
+            false
+        };
+    }
+    
+    public static IEnumerable<object[]> IsEqual_Cases_Timespan()
+    {
+        yield return new object[] { TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), true };
+        yield return new object[] { TimeSpan.FromSeconds(1), "00:00:01", true };
+        yield return new object[] { TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(0), false };
+        yield return new object[] { TimeSpan.FromSeconds(1), "10", false };
+        yield return new object[] { TimeSpan.FromSeconds(1), DateTime.Now, false };
+    }
+
+    public static IEnumerable<object[]> IsEqual_Cases_DateTime()
+    {
+        yield return new object[] { new DateTime(2023, 01, 01), new DateTime(2023, 01, 01), true };
+        yield return new object[] { new DateTime(2023, 01, 01), new DateTime(1900, 01, 01), false };
+        yield return new object[] { new DateTime(2023, 01, 01), "2023-01-01", true };
+        yield return new object[] { DateTime.Now, TimeSpan.FromSeconds(0), false };
+    }
+
+    private enum FirstEnum { One = 1, Two = 2 }
+
+    private enum SecondEnum { One = 1, Two = 2 }
+}


### PR DESCRIPTION
Improved mechanism of values comparison in built-in macros: `isEqual`, `isNotEqual`, `isLessEqual`, `isLessThan`, `isGreaterEqual`, `isGreaterThan`

For instance, previous implementation fails to handle following construct:
```
#isGreaterThan<DayOfMonth, 1900-01-02, sql {  ,[DayOfMonth]}>
```

```
System.InvalidCastException: 'Invalid cast from 'DateTime' to 'Double'.'
```

See [unit tests](https://github.com/sdcb/sdmap/pull/17/files#diff-54f8af4b6adfa0f53c9c16b919422cf0b5b5a812d6e47cf6a3b410dc73299166) for more cases